### PR TITLE
Do not wrap Throwable into Exception

### DIFF
--- a/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/Connection.kt
+++ b/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/Connection.kt
@@ -52,7 +52,7 @@ class Connection constructor(
     var onOpen: suspend () -> Unit = {}
     var onMessage: suspend (jsonString: String) -> Unit = {}
     var onClose: () -> Unit = {}
-    var onFailure: (e: Exception) -> Unit = {}
+    var onFailure: (e: Throwable) -> Unit = {}
 
     private var state = State.CONNECTING
 
@@ -156,7 +156,7 @@ class Connection constructor(
         }
     }
 
-    private fun fireOnFailure(error: Exception) {
+    private fun fireOnFailure(error: Throwable) {
         onFailure.invoke(error)
         if (isState(State.TERMINATING)) stopEventsHandler()
     }
@@ -185,7 +185,7 @@ class Connection constructor(
 
     private suspend fun handleFailure(throwable: Throwable) {
         state = State.CLOSED
-        fireOnFailure(Exception(throwable))
+        fireOnFailure(throwable)
     }
 
     private suspend fun handleClosure() {

--- a/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/Subscription.kt
+++ b/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/Subscription.kt
@@ -4,7 +4,7 @@ typealias ConnectedHandler = () -> Unit
 typealias RejectedHandler = () -> Unit
 typealias ReceivedHandler = (data: Any?) -> Unit
 typealias DisconnectedHandler = () -> Unit
-typealias FailedHandler = (e: Exception) -> Unit
+typealias FailedHandler = (e: Throwable) -> Unit
 
 /**
  * Subscription provides a number of callbacks and a method for calling remote procedure calls
@@ -67,7 +67,7 @@ class Subscription constructor(private val consumer: Consumer, channel: Channel)
         onDisconnected?.invoke()
     }
 
-    fun notifyFailed(error: Exception) {
+    fun notifyFailed(error: Throwable) {
         onFailed?.invoke(error)
     }
 }

--- a/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/Subscriptions.kt
+++ b/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/Subscriptions.kt
@@ -54,7 +54,7 @@ class Subscriptions constructor(private val consumer: Consumer) {
         subscriptions.filter { it.identifier == identifier }.forEach { it.notifyReceived(data) }
     }
 
-    fun notifyFailed(error: Exception) {
+    fun notifyFailed(error: Throwable) {
         subscriptions.forEach { it.notifyFailed(error) }
     }
 


### PR DESCRIPTION
Wrapping error into Exception hides a problem. 