### PR TITLE
Remove actor from EventsHandler

### DIFF
--- a/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/EventsHandler.kt
+++ b/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/EventsHandler.kt
@@ -1,7 +1,6 @@
 package com.vinted.actioncable.client.kotlin
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.actor
 import kotlin.coroutines.CoroutineContext
 
 class EventsHandler : CoroutineScope {
@@ -9,29 +8,16 @@ class EventsHandler : CoroutineScope {
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    private val actor = actor<suspend () -> Unit> {
-        for (msg in channel) {
-            msg.invoke()
-        }
-    }
-
     fun handle(operation: suspend () -> Unit) = launch {
-        send(operation)
+        operation.invoke()
     }
 
     fun handleWithDelay(operation: suspend () -> Unit, duration: Long) = launch {
         delay(duration)
-        send(operation)
-    }
-
-    private suspend fun send(operation: suspend () -> Unit) {
-        if (!actor.isClosedForSend) {
-            actor.send(operation)
-        }
+        operation.invoke()
     }
 
     fun stop() {
-        actor.close()
         coroutineContext.cancel()
     }
 }


### PR DESCRIPTION
Looks like unnecessary complexity at this point. Operation can be executed on worker thread from simple ```launch``` coroutine builder.