### PR TITLE
Set `Terminating` state in right time

### DIFF
--- a/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/Connection.kt
+++ b/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/Connection.kt
@@ -66,21 +66,19 @@ class Connection constructor(
         eventsHandler.handle(::performOpen)
     }
 
+    fun terminate() {
+        eventsHandler.handle {
+            state = State.TERMINATING
+            performClose()
+        }
+    }
+
     private suspend fun performOpen() {
         if (isOpen()) {
             fireOnFailure(IllegalStateException("Must close existing connection before opening"))
         } else {
             doOpen()
         }
-    }
-
-    private fun close() {
-        eventsHandler.handle(::performClose)
-    }
-
-    fun terminate() {
-        state = State.TERMINATING
-        close()
     }
 
     private suspend fun performClose() {
@@ -104,7 +102,7 @@ class Connection constructor(
             open()
         } else {
             isReopening = true
-            close()
+            eventsHandler.handle(::performClose)
         }
     }
 


### PR DESCRIPTION
Got some unexpected behaviour with previous implementation. This one ensures that ```State.TERMINATING``` will be set once actor will start executing termination operation instead of setting this state immediately. 