### PR TITLE
Add disconnect message type

### DIFF
--- a/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/Message.kt
+++ b/library/src/main/kotlin/com/vinted/actioncable/client/kotlin/Message.kt
@@ -17,6 +17,7 @@ data class Message(
         PING("ping"),
         CONFIRMATION("confirm_subscription"),
         REJECTION("reject_subscription"),
+        DISCONNECT("disconnect"),
         MESSAGE(null)
     }
 


### PR DESCRIPTION
ActionCable sends this message in case the connection is rejected (e.g.
because of failed authorization)

Before this change, receiving a disconnect message crashes the app

After this change, the disconnect message is ignored, which is OK
because ActionCable will disconnect anyway.